### PR TITLE
Add support for types with lifetime parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ syn = "1.0"
 
 [dev-dependencies]
 heapless = { version = "0.5.6", default-features = false, features = ["serde"] }
-serde = { version = "1", default-features = false }
+# "alloc" feature required to test serde traits on borrowed data (Cow)
+serde = { version = "1", default-features = false, features = ["alloc"] }
 serde_cbor = { version = "0.11.0", default-features = false }
 utilities = { path = "utilities" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ syn = "1.0"
 heapless = { version = "0.5.6", default-features = false, features = ["serde"] }
 serde = { version = "1", default-features = false }
 serde_cbor = { version = "0.11.0", default-features = false }
+utilities = { path = "utilities" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,11 +83,12 @@ fn count_serialized_fields(fields: &[parse::Field]) -> Vec<proc_macro2::TokenStr
 pub fn derive_serialize(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as Input);
     let ident = input.ident;
+    let generics = input.generics;
     let num_fields = count_serialized_fields(&input.fields);
     let serialize_fields = serialize_fields(&input.fields, input.attrs.offset);
 
     TokenStream::from(quote! {
-        impl serde::Serialize for #ident {
+        impl #generics serde::Serialize for #ident #generics {
             fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
             where
                 S: serde::Serializer

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,9 +1,10 @@
 use proc_macro2::Span;
 use syn::parse::{Error, Parse, ParseStream, Result};
-use syn::{Data, DeriveInput, Fields, Ident, Token};
+use syn::{Data, DeriveInput, Fields, Generics, Ident, Token};
 
 pub struct Input {
     pub ident: Ident,
+    pub generics: Generics,
     pub attrs: StructAttrs,
     pub fields: Vec<Field>,
 }
@@ -100,6 +101,7 @@ impl Parse for Input {
             ident: derive_input.ident,
             attrs,
             fields,
+            generics: derive_input.generics,
         })
     }
 }

--- a/tests/basics.rs
+++ b/tests/basics.rs
@@ -1,43 +1,9 @@
 use serde_indexed::{DeserializeIndexed, SerializeIndexed};
 
-/// buffer should be big enough to hold serialized object.
-fn cbor_serialize<T: serde::Serialize>(
-    object: &T,
-    buffer: &mut [u8],
-) -> Result<usize, serde_cbor::Error> {
-    let writer = serde_cbor::ser::SliceWrite::new(buffer);
-    let mut ser = serde_cbor::Serializer::new(writer);
-
-    object.serialize(&mut ser)?;
-
-    let writer = ser.into_inner();
-    let size = writer.bytes_written();
-
-    Ok(size)
-}
-
-/// may or may not modify buffer to hold temporary data.
-/// buffer may be longer than serialized T.
-fn cbor_deserialize<'de, T: serde::Deserialize<'de>>(
-    buffer: &'de mut [u8],
-) -> Result<T, serde_cbor::Error> {
-    let mut deserializer = serde_cbor::de::Deserializer::from_mut_slice(buffer);
-    serde::Deserialize::deserialize(&mut deserializer)
-}
-
-/// scratch should be big enough to hold temporary data.
-/// buffer must not have trailing data.
-fn cbor_deserialize_with_scratch<'de, T: serde::Deserialize<'de>>(
-    buffer: &'de [u8],
-    scratch: &'de mut [u8],
-) -> Result<T, serde_cbor::Error> {
-    serde_cbor::de::from_slice_with_scratch(buffer, scratch)
-}
-
 mod some_keys {
     use super::*;
-
     use heapless::consts;
+    use utilities::{cbor_serialize, cbor_deserialize, cbor_deserialize_with_scratch};
 
     #[derive(Clone, Debug, PartialEq, SerializeIndexed, DeserializeIndexed)]
     #[serde_indexed(offset = 1)]

--- a/tests/lifetimes.rs
+++ b/tests/lifetimes.rs
@@ -1,0 +1,29 @@
+use serde_indexed::SerializeIndexed;
+use utilities::cbor_serialize;
+
+#[derive(SerializeIndexed)]
+#[serde_indexed(offset = 1)]
+struct WithLifetimes<'a> {
+    shared_data: &'a [u8],
+        #[serde(skip_serializing_if = "Option::is_none")]
+        option: Option<u8>,
+}
+
+fn lifetime_example<'a>() -> WithLifetimes<'a> {
+    WithLifetimes {
+        shared_data: &[1, 2, 3],
+        option: None,
+    }
+}
+
+const SERIALIZED_LIFETIME_EXAMPLE: &'static [u8] = b"\xa1\x01\x83\x01\x02\x03";
+
+#[test]
+fn serialize() {
+    let data = lifetime_example();
+    let mut buf = [0u8; 64];
+
+    let size = cbor_serialize(&data, &mut buf).unwrap();
+
+    assert_eq!(&buf[..size], SERIALIZED_LIFETIME_EXAMPLE);
+}

--- a/utilities/.gitignore
+++ b/utilities/.gitignore
@@ -1,0 +1,3 @@
+/target
+**/*.rs.bk
+Cargo.lock

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "utilities"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde = { version = "1", default-features = false }
+serde_cbor = { version = "0.11.0", default-features = false }

--- a/utilities/src/lib.rs
+++ b/utilities/src/lib.rs
@@ -1,0 +1,34 @@
+/// buffer should be big enough to hold serialized object.
+pub fn cbor_serialize<T: serde::Serialize>(
+    object: &T,
+    buffer: &mut [u8],
+) -> Result<usize, serde_cbor::Error> {
+    let writer = serde_cbor::ser::SliceWrite::new(buffer);
+    let mut ser = serde_cbor::Serializer::new(writer);
+
+    object.serialize(&mut ser)?;
+
+    let writer = ser.into_inner();
+    let size = writer.bytes_written();
+
+    Ok(size)
+}
+
+/// may or may not modify buffer to hold temporary data.
+/// buffer may be longer than serialized T.
+pub fn cbor_deserialize<'de, T: serde::Deserialize<'de>>(
+    buffer: &'de mut [u8],
+) -> Result<T, serde_cbor::Error> {
+    let mut deserializer = serde_cbor::de::Deserializer::from_mut_slice(buffer);
+    serde::Deserialize::deserialize(&mut deserializer)
+}
+
+/// scratch should be big enough to hold temporary data.
+/// buffer must not have trailing data.
+pub fn cbor_deserialize_with_scratch<'de, T: serde::Deserialize<'de>>(
+    buffer: &'de [u8],
+    scratch: &'de mut [u8],
+) -> Result<T, serde_cbor::Error> {
+    serde_cbor::de::from_slice_with_scratch(buffer, scratch)
+}
+


### PR DESCRIPTION
I have some types using `std::borrow::Cow` so that I can use borrowed data during serialization but can also deserialize into owned types. As a result, these types need a lifetime parameter to pass onto the Cow fields.

This adds some code to the derive implementation that adds the necessary lifetime parameters to the code (pretty much wherever an `#ident` is used).

The basic tests still pass so, as far as I'm aware, none of these changes should affect types without lifetime parameters.

I'm not sure if this is a usecase you want to support, but I figured I would make a PR in case it's useful to anyone else.