### PR TITLE
Add full support for generics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ serde = { version = "1" }
 serde-byte-array = "0.1.2"
 serde_bytes = { version = "0.11.12", default-features = false }
 serde_cbor = { version = "0.11.0" }
+serde_test = "1.0.176"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,9 +136,8 @@ fn unwrap_expected_fields(fields: &[parse::Field]) -> Vec<proc_macro2::TokenStre
                     let #ident = #ident.ok_or_else(|| serde::de::Error::missing_field(#label))?;
                 }
             } else {
-                // TODO: still confused here, but the tests pass ;)
                 quote! {
-                    // let #ident = #ident.or(None);
+                    let #ident = #ident.unwrap_or_default();
                 }
             }
         })

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,13 +1,13 @@
 use proc_macro2::Span;
 use syn::meta::ParseNestedMeta;
 use syn::parse::{Error, Parse, ParseStream, Result};
-use syn::{Data, DeriveInput, Fields, Ident, Lifetime, LitInt, LitStr, Token};
+use syn::{Data, DeriveInput, Fields, Generics, Ident, LitInt, LitStr, Token};
 
 pub struct Input {
     pub ident: Ident,
     pub attrs: StructAttrs,
     pub fields: Vec<Field>,
-    pub lifetimes: Vec<Lifetime>,
+    pub generics: Generics,
 }
 
 #[derive(Default)]
@@ -54,10 +54,6 @@ fn parse_attrs(attrs: &Vec<syn::Attribute>) -> Result<StructAttrs> {
     Ok(struct_attrs)
 }
 
-fn lifetimes(generics: &syn::Generics) -> Vec<Lifetime> {
-    generics.lifetimes().map(|l| l.lifetime.clone()).collect()
-}
-
 impl Parse for Input {
     fn parse(input: ParseStream) -> Result<Self> {
         let call_site = Span::call_site();
@@ -81,15 +77,13 @@ impl Parse for Input {
 
         let fields = fields_from_ast(&syn_fields.named)?;
 
-        let lifetimes = lifetimes(&derive_input.generics);
-
         //serde::internals::ast calls `fields_from_ast(cx, &fields.named, attrs, container_default)`
 
         Ok(Input {
             ident: derive_input.ident,
             attrs,
             fields,
-            lifetimes,
+            generics: derive_input.generics,
         })
     }
 }


### PR DESCRIPTION
This PR adds support for `const` generics and generic types, in addition to the current support for lifetime generics.

In testing the PR with `serde-test`, this also showed the underlying bug for #2 (the `Token::Some` failed to de-serialize), so this PR includes a fix.

Fix #9 and #2 