### PR TITLE
Add support for `serde(skip)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 [Unreleased]: https://github.com/trussed-dev/serde-indexed/compare/0.1.1...HEAD
 
--
+- Add support for `#[serde(skip)]` ([#14][])
+- Add support for generics ([#11][])
+
+[#14]: https://github.com/trussed-dev/serde-indexed/pull/14
+[#11]: https://github.com/trussed-dev/serde-indexed/pull/11
 
 ## [v0.1.1][] (2024-04-03)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ fn serialize_fields(fields: &[parse::Field], offset: usize) -> Vec<proc_macro2::
                     }
                 }),
                 Skip::Always => None,
-                Skip::None => Some(quote! {
+                Skip::Never => Some(quote! {
                     map.serialize_entry(&#index, &self.#member)?;
                 }),
             }
@@ -72,7 +72,7 @@ fn count_serialized_fields(fields: &[parse::Field]) -> Vec<proc_macro2::TokenStr
                 }
                 Skip::Always => quote! { 0 },
 
-                Skip::None => {
+                Skip::Never => {
                     quote! { 1 }
                 }
             }
@@ -133,7 +133,7 @@ fn unwrap_expected_fields(fields: &[parse::Field]) -> Vec<proc_macro2::TokenStre
             let label = field.label.clone();
             let ident = format_ident!("{}", &field.label);
             match field.skip_serializing_if {
-                Skip::None => quote! {
+                Skip::Never => quote! {
                     let #ident = #ident.ok_or_else(|| serde::de::Error::missing_field(#label))?;
                 },
                 Skip::If(_) => quote! {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -17,14 +17,14 @@ pub struct StructAttrs {
 }
 
 pub enum Skip {
-    None,
+    Never,
     If(syn::ExprPath),
     Always,
 }
 
 impl Skip {
     pub fn is_none(&self) -> bool {
-        matches!(self, Self::None)
+        matches!(self, Self::Never)
     }
     pub fn is_always(&self) -> bool {
         matches!(self, Self::Always)
@@ -114,7 +114,7 @@ fn fields_from_ast(
             let current_index = index;
             index += 1;
 
-            let mut skip_serializing_if = Skip::None;
+            let mut skip_serializing_if = Skip::Never;
             for attr in &field.attrs {
                 if attr.path().is_ident("serde") {
                     attr.parse_nested_meta(|meta| {

--- a/tests/basics.rs
+++ b/tests/basics.rs
@@ -59,6 +59,8 @@ mod some_keys {
         pub number: i32,
         #[serde(skip)]
         pub ignored: i32,
+        #[serde(skip(no_increment))]
+        pub ignored2: i32,
         pub bytes: &'a ByteArray<7>,
         pub string: &'b str,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -111,6 +113,7 @@ mod some_keys {
         let value = SomeRefKeys {
             number: -7,
             ignored: 0,
+            ignored2: 0,
             bytes: &BYTE_ARRAY,
             string: "so serde",
             option: None,

--- a/tests/basics.rs
+++ b/tests/basics.rs
@@ -57,6 +57,8 @@ mod some_keys {
     #[serde_indexed(offset = 1)]
     pub struct SomeRefKeys<'a, 'b, 'c> {
         pub number: i32,
+        #[serde(skip)]
+        pub ignored: i32,
         pub bytes: &'a ByteArray<7>,
         pub string: &'b str,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -108,13 +110,14 @@ mod some_keys {
         const BYTE_ARRAY: ByteArray<7> = ByteArray::new([37u8; 7]);
         let value = SomeRefKeys {
             number: -7,
+            ignored: 0,
             bytes: &BYTE_ARRAY,
             string: "so serde",
             option: None,
             vector: Bytes::new(&[42]),
         };
-        // in Python: cbor2.dumps({1: -7, 2: bytes([37]*7), 3: "so serde", 5: bytes([42]*1)}).
-        let serialized: &[u8] = &hex!("a401260247252525252525250368736f20736572646505412a");
+        // in Python: cbor2.dumps({1: -7, 3: bytes([37]*7), 4: "so serde", 6: bytes([42]*1)}).
+        let serialized: &[u8] = &hex!("a401260347252525252525250468736f20736572646506412a");
         (serialized, value)
     }
 
@@ -130,8 +133,8 @@ mod some_keys {
     fn another_ref_example() -> (&'static [u8], SomeRefKeys<'static, 'static, 'static>) {
         let (_, mut an_example) = a_ref_example();
         an_example.option = Some(0xff);
-        // in Python: cbor2.dumps({1: -7, 2: bytes([37]*7), 3: "so serde", 4: 0xff,  5: bytes([42]*1)}).hex()
-        let serialized: &[u8] = &hex!("a501260247252525252525250368736f2073657264650418ff05412a");
+        // in Python: cbor2.dumps({1: -7, 3: bytes([37]*7), 4: "so serde", 5: 0xff,  6: bytes([42]*1)}).hex()
+        let serialized: &[u8] = &hex!("a501260347252525252525250468736f2073657264650518ff06412a");
         (serialized, an_example)
     }
 
@@ -196,11 +199,11 @@ mod some_keys {
                 Token::Map { len: Some(4) },
                 Token::U64(1),
                 Token::I32(-7),
-                Token::U64(2),
-                Token::BorrowedBytes(&[37; 7]),
                 Token::U64(3),
+                Token::BorrowedBytes(&[37; 7]),
+                Token::U64(4),
                 Token::BorrowedStr("so serde"),
-                Token::U64(5),
+                Token::U64(6),
                 Token::BorrowedBytes(&[42]),
                 Token::MapEnd,
             ],
@@ -211,14 +214,14 @@ mod some_keys {
                 Token::Map { len: Some(5) },
                 Token::U64(1),
                 Token::I32(-7),
-                Token::U64(2),
-                Token::BorrowedBytes(&[37; 7]),
                 Token::U64(3),
-                Token::BorrowedStr("so serde"),
+                Token::BorrowedBytes(&[37; 7]),
                 Token::U64(4),
+                Token::BorrowedStr("so serde"),
+                Token::U64(5),
                 Token::Some,
                 Token::U8(0xFF),
-                Token::U64(5),
+                Token::U64(6),
                 Token::BorrowedBytes(&[42]),
                 Token::MapEnd,
             ],


### PR DESCRIPTION
`skip` causes the index to not be increased to match deserialization from upstream `serde`.