### PR TITLE
Allow unexpected fields

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,8 @@ pub fn derive_deserialize(input: TokenStream) -> TokenStream {
                 match __serde_indexed_internal_key {
                     #(#match_fields)*
                     _ => {
-                        return Err(serde::de::Error::duplicate_field("inexistent field index"));
+                        // Ignore unknown keys by consuming their value
+                        let _ = map.next_value::<serde::de::IgnoredAny>()?;
                     }
                 }
             }


### PR DESCRIPTION
We're using serde-indexed in [libwebauthn](https://github.com/linux-credentials/libwebauthn), which implements the platform side of the CTAP spec.

When deserializing, the CTAP spec mandates unknown fields should be ignored. Without this, we just can't use serde-indexed, in favour of [parsing structures manually](https://github.com/linux-credentials/libwebauthn/blob/006b8f904a3cd9813ee3b7da749ebda1cb8e9f9b/libwebauthn/src/transport/cable/tunnel.rs#L591-L592).

I think this should be safe to merge as backwards compatible because:
* All working inputs will continue working;
* Ignoring unexpected fields is the default behaviour of serde's `#[derive(Serialize)]` and `#[derive(Deserialize)]`, so it can be considered expected behaviours;
* Behaviour for unexpected inputs currently does not specify otherwise.