### PR TITLE
Prefer explicit indexing over automatically assigned indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - No longer fails deserialising maps with unknown fields ([#19][])
 - Prefer explicit indexing over automatically assigned indices ([#17][]):
   - Require `auto_index` attribute to enable automatic index assignment
+  - Add `index` attribute for explicit index assignment
 
 [#2]: https://github.com/trussed-dev/serde-indexed/issues/2
 [#11]: https://github.com/trussed-dev/serde-indexed/pull/11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@
 - Add support for generics ([#11][])
 - skip_serializing_if no longer incorrectly affects deserialization (fixes [#2][])
 - No longer fails deserialising maps with unknown fields ([#19][])
+- Prefer explicit indexing over automatically assigned indices ([#17][]):
+  - Require `auto_index` attribute to enable automatic index assignment
 
 [#2]: https://github.com/trussed-dev/serde-indexed/issues/2
 [#11]: https://github.com/trussed-dev/serde-indexed/pull/11
 [#14]: https://github.com/trussed-dev/serde-indexed/pull/14
 [#16]: https://github.com/trussed-dev/serde-indexed/pull/16
+[#17]: https://github.com/trussed-dev/serde-indexed/issues/17
 [#19]: https://github.com/trussed-dev/serde-indexed/pull/19
 
 ## [v0.1.1][] (2024-04-03)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ and a custom `offset` container attribute.
 use serde_indexed::{DeserializeIndexed, SerializeIndexed};
 
 #[derive(Clone, Debug, PartialEq, SerializeIndexed, DeserializeIndexed)]
-#[serde_indexed(offset = 1)]
+#[serde_indexed(auto_index, offset = 1)]
 pub struct SomeKeys {
     pub number: i32,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,11 +8,12 @@ and a custom `offset` container attribute.
 use serde_indexed::{DeserializeIndexed, SerializeIndexed};
 
 #[derive(Clone, Debug, PartialEq, SerializeIndexed, DeserializeIndexed)]
-#[serde_indexed(auto_index, offset = 1)]
 pub struct SomeKeys {
+    #[serde(index = 1)]
     pub number: i32,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(index = 2, skip_serializing_if = "Option::is_none")]
     pub option: Option<u8>,
+    #[serde(index = 3)]
     pub bytes: [u8; 7],
 }
 ```

--- a/tests/basics.rs
+++ b/tests/basics.rs
@@ -43,7 +43,7 @@ mod some_keys {
     use serde_test::assert_de_tokens;
 
     #[derive(Clone, Debug, PartialEq, SerializeIndexed, DeserializeIndexed)]
-    #[serde_indexed(offset = 1)]
+    #[serde_indexed(auto_index, offset = 1)]
     pub struct SomeKeys {
         pub number: i32,
         pub bytes: [u8; 7],
@@ -54,7 +54,7 @@ mod some_keys {
     }
 
     #[derive(Clone, Debug, PartialEq, SerializeIndexed, DeserializeIndexed)]
-    #[serde_indexed(offset = 1)]
+    #[serde_indexed(auto_index, offset = 1)]
     pub struct SomeRefKeys<'a, 'b, 'c> {
         pub number: i32,
         #[serde(skip)]
@@ -70,6 +70,7 @@ mod some_keys {
 
     #[derive(Clone, Debug, PartialEq, SerializeIndexed, DeserializeIndexed)]
     // #[serde_indexed(offset = 1)]
+    #[serde_indexed(auto_index)]
     pub struct NakedOption {
         pub option: Option<SomeKeys>,
         pub num: usize,
@@ -78,6 +79,7 @@ mod some_keys {
 
     #[derive(Clone, Debug, PartialEq, SerializeIndexed, DeserializeIndexed)]
     // #[serde_indexed(offset = 1)]
+    #[serde_indexed(auto_index)]
     pub struct NakedRefOption<'a, 'b, 'c> {
         pub option: Option<SomeRefKeys<'a, 'b, 'c>>,
         pub num: usize,
@@ -86,6 +88,7 @@ mod some_keys {
 
     #[derive(Clone, Debug, PartialEq, SerializeIndexed, DeserializeIndexed)]
     // #[serde_indexed(offset = 1)]
+    #[serde_indexed(auto_index)]
     pub struct EmptyStruct {}
 
     fn an_example() -> (&'static [u8], SomeKeys) {
@@ -355,7 +358,7 @@ mod cow {
     use std::borrow::Cow;
 
     #[derive(PartialEq, Debug, SerializeIndexed, DeserializeIndexed)]
-    #[serde_indexed(offset = 1)]
+    #[serde_indexed(auto_index, offset = 1)]
     struct WithLifetimes<'a> {
         data: Cow<'a, [u8]>,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -419,7 +422,7 @@ mod generics {
     use serde_test::{assert_de_tokens, assert_ser_tokens};
 
     #[derive(PartialEq, Debug, SerializeIndexed, DeserializeIndexed)]
-    #[serde_indexed(offset = 1)]
+    #[serde_indexed(auto_index, offset = 1)]
     struct WithGeneric<T> {
         data: T,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -434,7 +437,7 @@ mod generics {
     }
 
     #[derive(PartialEq, Debug, SerializeIndexed, DeserializeIndexed)]
-    #[serde_indexed(offset = 1)]
+    #[serde_indexed(auto_index, offset = 1)]
     struct WithConstGeneric<const N: usize> {
         data: ByteArray<N>,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -483,7 +486,7 @@ mod generics {
     }
 
     #[derive(PartialEq, Debug, SerializeIndexed, DeserializeIndexed)]
-    #[serde_indexed(offset = 1)]
+    #[serde_indexed(auto_index, offset = 1)]
     struct WithAllGenerics<'a, 'b, T, I, const N: usize, const Z: usize> {
         data1: heapless::Vec<T, N>,
         data2: heapless::Vec<I, Z>,
@@ -525,6 +528,7 @@ mod generics {
     #[test]
     fn serialize_with() {
         #[derive(serde_indexed::SerializeIndexed)]
+        #[serde_indexed(auto_index)]
         struct SerializeWith {
             #[serde(serialize_with = "serde_bytes::serialize")]
             data: Vec<u8>,
@@ -546,6 +550,7 @@ mod generics {
     #[test]
     fn deserialize_with() {
         #[derive(serde_indexed::DeserializeIndexed, PartialEq, Eq, Debug)]
+        #[serde_indexed(auto_index)]
         struct DeserializeWith {
             #[serde(deserialize_with = "serde_bytes::deserialize")]
             data: Vec<u8>,
@@ -569,6 +574,7 @@ mod generics {
         #[derive(
             serde_indexed::SerializeIndexed, serde_indexed::DeserializeIndexed, PartialEq, Eq, Debug,
         )]
+        #[serde_indexed(auto_index)]
         struct SerializeWith {
             #[serde(with = "serde_bytes")]
             data: Vec<u8>,
@@ -592,6 +598,7 @@ mod generics {
         #[derive(
             serde_indexed::SerializeIndexed, serde_indexed::DeserializeIndexed, PartialEq, Eq, Debug,
         )]
+        #[serde_indexed(auto_index)]
         struct SerializeWith<'a> {
             #[serde(with = "serde_bytes")]
             data: &'a [u8],

--- a/tests/basics.rs
+++ b/tests/basics.rs
@@ -617,3 +617,42 @@ mod generics {
         )
     }
 }
+
+mod index {
+    use super::*;
+
+    #[derive(PartialEq, Debug, SerializeIndexed, DeserializeIndexed)]
+    struct WithIndices {
+        #[serde(index = 9)]
+        test1: usize,
+        #[serde(index = 2)]
+        test2: usize,
+        #[serde(index = 0x5A)]
+        test3: usize,
+    }
+
+    fn indices_example() -> WithIndices {
+        WithIndices {
+            test1: 42,
+            test2: 1,
+            test3: 99,
+        }
+    }
+
+    #[test]
+    fn tokens() {
+        assert_tokens(
+            &indices_example(),
+            &[
+                Token::Map { len: Some(3) },
+                Token::U64(9),
+                Token::U64(42),
+                Token::U64(2),
+                Token::U64(1),
+                Token::U64(0x5A),
+                Token::U64(99),
+                Token::MapEnd,
+            ],
+        );
+    }
+}


### PR DESCRIPTION
This PR adds an `index` attribute for explicit index assignment and makes the old automatic index assignment opt-in with the `auto_index` attribute.

This means that this old code

```rust
#[derive(DeserializeIndexed, SerializedIndex)]
struct S {
    a: int,
    b: int,
}
```

now has to be written like this:

```rust
#[derive(DeserializeIndexed, SerializedIndex)]
#[serde(auto_index)]
struct S {
    a: int,
    b: int,
}

#[derive(DeserializeIndexed, SerializedIndex)]
struct S {
    #[serde(index = 0)]
    a: int,
    #[serde(index = 1)]
    b: int,
}
```

Fixes: https://github.com/trussed-dev/serde-indexed/issues/17