### PR TITLE
Don’t require explicit index for skipped fields

### DIFF
--- a/tests/basics.rs
+++ b/tests/basics.rs
@@ -629,6 +629,8 @@ mod index {
         test2: usize,
         #[serde(index = 0x5A)]
         test3: usize,
+        #[serde(skip)]
+        test4: usize,
     }
 
     fn indices_example() -> WithIndices {
@@ -636,6 +638,7 @@ mod index {
             test1: 42,
             test2: 1,
             test3: 99,
+            test4: 0,
         }
     }
 


### PR DESCRIPTION
This patch allows for fields that are always skipped to not have an explicit index attribute so that users don’t have to assign bogus indices that are never used.